### PR TITLE
Add Optional Fields

### DIFF
--- a/src/data/dtoOptional.json
+++ b/src/data/dtoOptional.json
@@ -17,6 +17,7 @@
   "match-v4.ParticipantDto.highestAchievedSeasonTier": true,
 
 
+  "match-v4.ParticipantDto.timeline": true,
   "match-v4.ParticipantTimelineDto.*": true,
   "match-v4.ParticipantTimelineDto.participantId": true,
   "match-v4.ParticipantTimelineDto.lane": true,
@@ -46,7 +47,7 @@
   "match-v4.ParticipantStatsDto.item6": false,
 
   "match-v4.ParticipantStatsDto.visionWardsBoughtInGame": false,
-  "match-v4.ParticipantStatsDto.wardsKilled": false,
+  "match-v4.ParticipantStatsDto.wardsKilled": true,
 
   "match-v4.ParticipantStatsDto.totalHeal": false,
   "match-v4.ParticipantStatsDto.totalUnitsHealed": false,
@@ -87,8 +88,8 @@
 
   "match-v4.ParticipantStatsDto.totalMinionsKilled": false,
   "match-v4.ParticipantStatsDto.neutralMinionsKilled": false,
-  "match-v4.ParticipantStatsDto.neutralMinionsKilledTeamJungle": false,
-  "match-v4.ParticipantStatsDto.neutralMinionsKilledEnemyJungle": false,
+  "match-v4.ParticipantStatsDto.neutralMinionsKilledTeamJungle": true,
+  "match-v4.ParticipantStatsDto.neutralMinionsKilledEnemyJungle": true,
 
 
   "match-v4.PlayerDto.summonerId": true,

--- a/src/data/dtoOptional.json
+++ b/src/data/dtoOptional.json
@@ -22,7 +22,8 @@
   "match-v4.ParticipantTimelineDto.lane": true,
   "match-v4.ParticipantTimelineDto.role": true,
 
-
+  "match-v4.MatchReferenceDto.lane": true,
+  "match-v4.MatchReferenceDto.role": true,
 
   "match-v4.ParticipantStatsDto.*": true,
 

--- a/src/data/dtoOptional.json
+++ b/src/data/dtoOptional.json
@@ -47,7 +47,6 @@
   "match-v4.ParticipantStatsDto.item6": false,
 
   "match-v4.ParticipantStatsDto.visionWardsBoughtInGame": false,
-  "match-v4.ParticipantStatsDto.wardsKilled": true,
 
   "match-v4.ParticipantStatsDto.totalHeal": false,
   "match-v4.ParticipantStatsDto.totalUnitsHealed": false,
@@ -88,8 +87,6 @@
 
   "match-v4.ParticipantStatsDto.totalMinionsKilled": false,
   "match-v4.ParticipantStatsDto.neutralMinionsKilled": false,
-  "match-v4.ParticipantStatsDto.neutralMinionsKilledTeamJungle": true,
-  "match-v4.ParticipantStatsDto.neutralMinionsKilledEnemyJungle": true,
 
 
   "match-v4.PlayerDto.summonerId": true,


### PR DESCRIPTION
Ran into some issues using [Riven](https://github.com/MingweiSamuel/Riven) with some weirdly formatted match details in my personal match history.

Odyssey game lacking `match-v4.ParticipantDto.timeline` field: 
```
https://na1.api.riotgames.com/lol/match/v4/matches/2881976826
```
This Odyssey game was also missing `match-v4.MatchReferenceDto.lane` and `match-v4.MatchReferenceDto.role` in 
the matchlist endpoint (although that's a bit more difficult to link to, you can look up the account ID for summoner "haha yes" on NA to verify):
```
https://na1.api.riotgames.com/lol/match/v4/matchlists/by-account/<ACCOUNT ID>?endIndex=2600&beginIndex=2500
```

ARAM game lacking `match-v4.ParticipantStatsDto.neutralMinionsKilledTeamJungle`, `match-v4.ParticipantStatsDto.neutralMinionsKilledEnemyJungle`, and `match-v4.ParticipantStatsDto.wardsKilled`:
```
https://na1.api.riotgames.com/lol/match/v4/matches/3596184782
```

I'm not sure if you're willing to accept this PR as it results in breaking API changes when generated into the Rust library (types change to `Option<T>`) and perhaps some of the other libraries you maintain. Feel free to reject if you value the API stability.