### PR TITLE
Update TOS links

### DIFF
--- a/src/openapi-3.0.0.js
+++ b/src/openapi-3.0.0.js
@@ -47,7 +47,7 @@ function toSpec({ endpoints, regions, description, schemaOverrides }) {
     info: {
       title: "Riot API",
       description,
-      termsOfService: "https://developer.riotgames.com/terms-and-conditions.html"
+      termsOfService: "https://developer.riotgames.com/terms"
     },
     servers: [
       {

--- a/src/swaggerspec-2.0.js
+++ b/src/swaggerspec-2.0.js
@@ -106,7 +106,7 @@ function toSpec({ endpoints, regions, description, schemaOverrides }) {
     info: {
       title: "Riot API",
       description,
-      termsOfService: "https://developer.riotgames.com/terms-and-conditions.html"
+      termsOfService: "https://developer.riotgames.com/terms"
     },
     // Use NA1 as default region.
     host: "na1.api.riotgames.com",


### PR DESCRIPTION
Not sure when the links broke, but Riot seems to have changed the locations of their TOS pages.