### PR TITLE
Add ULTBOOK (Ultimate Spellbook) to gameModes.json

### DIFF
--- a/src/enums/gameModes.json
+++ b/src/enums/gameModes.json
@@ -1,5 +1,9 @@
 [
     {
+        "gameMode": "ULTBOOK",
+        "description": "Ultimate Spellbook games."
+    },
+    {
         "gameMode": "GAMEMODEX",
         "description": "Nexus Blitz games, deprecated in patch 9.2 in favor of gameMode NEXUSBLITZ."
     },


### PR DESCRIPTION
Should fix GameMode enum in Camille and Riven:

Camille:
```System.Text.Json.JsonException: The JSON value could not be converted to Camille.Enums.GameMode. Path: $.gameMode | LineNumber: 0 | BytePositionInLine: 52.```
