### PR TITLE
Add gameTypes as reported by SpectatorV4 after 14.1 updates

### DIFF
--- a/src/enums/gameTypes.json
+++ b/src/enums/gameTypes.json
@@ -1,1 +1,14 @@
-[]
+[
+    {
+        "gametype": "CUSTOM",
+        "description": "Custom games"
+    },
+    {
+        "gametype": "TUTORIAL",
+        "description": "Tutorial games"
+    },
+    {
+        "gametype": "MATCHED",
+        "description": "all other games"
+    }
+]


### PR DESCRIPTION
See also https://github.com/MingweiSamuel/Camille/issues/102 and https://github.com/RiotGames/developer-relations/issues/878.

I hope it works like this; it's based on https://static.developer.riotgames.com/docs/lol/gameTypes.json but without the `_GAME`. I know `MATCHED` and `CUSTOM` is reported like that, Tutorial isn't usually able to be spectated, but added just for completeness.