### PR TITLE
 Add TFT queue 6000 (Set 3.5 Revival)

### DIFF
--- a/src/enums/queues.json
+++ b/src/enums/queues.json
@@ -52,5 +52,11 @@
         "map": "Arena",
         "description": "2v2v2v2 `CHERRY` games",
         "notes": null
+    },
+    {
+        "queueId": 6000,
+        "map": "Convergence",
+        "description": "Teamfight Tactics Set 3.5 Revival games",
+        "notes": null
     }
 ]


### PR DESCRIPTION
Example TFT game id using the new queue id: EUW1_6786745342 (game date: 2024-01-26)